### PR TITLE
refactor header: fixed top bar, nav fixed bottom-right

### DIFF
--- a/components/Header/HomeButton.js/homebutton.module.css
+++ b/components/Header/HomeButton.js/homebutton.module.css
@@ -1,14 +1,8 @@
 .homebutton {
-  color: black;
-  margin-left: 0px;
-  margin-top: 0px;
+  color: blue;
   font-family: Arial, Helvetica, sans-serif;
   padding-left: 20px;
-  text-decoration: none;
   border-bottom: 2px solid black;
   text-decoration: none;
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  background-color: white;
+  /* removed: position fixed, top, z-index, background-color — parent header handles these */
 }

--- a/components/Header/HomeButton.js/index.js
+++ b/components/Header/HomeButton.js/index.js
@@ -4,7 +4,7 @@ import styles from "./homebutton.module.css";
 export default function HomeButton() {
   return (
     <Link href="/">
-      <h1 className={styles.homebutton}>Ana Brena Cecilia</h1>
+      <h1 className={styles.homebutton}>Ana Cecilia Breña</h1>
     </Link>
   );
 }

--- a/components/Header/Navigation/navigation.module.css
+++ b/components/Header/Navigation/navigation.module.css
@@ -3,16 +3,16 @@
 /* Basic styling for the navigation bar */
 .navbar {
   display: flex;
-  justify-content: left;
+  justify-content: flex-end;
   align-items: center;
   background-color: transparent;
   padding: 10px;
-  position: fixed;
-  width: 100%;
   font-size: 24px;
-  bottom: 20px;
-  z-index: 1000;
   font-family: Arial, Helvetica, sans-serif;
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 1000;
 }
 
 /* Style for the navigation links */

--- a/components/Header/header.module.css
+++ b/components/Header/header.module.css
@@ -1,0 +1,7 @@
+.header {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 1000;
+  background-color: transparent;
+}

--- a/components/Header/index.js
+++ b/components/Header/index.js
@@ -1,11 +1,17 @@
 import HomeButton from "./HomeButton.js";
 import LoginBadge from "./LoginBaddge.js/index.js";
 import { Navigation } from "./Navigation";
+import styles from "./header.module.css";
+
 export default function Header() {
   return (
     <>
-      <HomeButton />
-      <LoginBadge />
+      {/* fixed top bar with site title */}
+      <header className={styles.header}>
+        <HomeButton />
+        <LoginBadge />
+      </header>
+      {/* nav stays fixed at bottom-right, outside the header */}
       <Navigation />
     </>
   );

--- a/components/Worms/index.js
+++ b/components/Worms/index.js
@@ -45,7 +45,7 @@ export default function WormPicture({ selectedWorm }) {
           />
 
           <Link href={`/works/${randomWork.slug}`}>
-            <p> {selectedWorm.label}</p>
+            {/* <p> {selectedWorm.label}</p> */}
           </Link>
         </div>
       </Draggable>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -23,7 +23,10 @@ export default function App({
           <SWRConfig value={{ fetcher }}>
             <GlobalStyle />
             <Header />
-            <Component {...pageProps} />
+            {/* padding-top clears the fixed header so content doesn't hide under it */}
+            <main style={{ paddingTop: "80px" }}>
+              <Component {...pageProps} />
+            </main>
           </SWRConfig>
         </SessionProvider>
       </ThemeProvider>


### PR DESCRIPTION
- Wrap HomeButton and LoginBadge in a fixed <header> element
- Move Navigation outside header, restore fixed bottom-right positioning
- Add padding-top to main so content clears the fixed header
- Clean up homebutton.module.css (remove redundant fixed positioning)