### PR TITLE
add toggleable sidebar with search, worm, and bio

### DIFF
--- a/components/Header/Navigation/index.js
+++ b/components/Header/Navigation/index.js
@@ -20,7 +20,7 @@ export function Navigation() {
         {isMenuOpen && (
           <div className={styles.menuItems}>
             <Link href="/works" passHref>
-              <div className={styles.works}>Works</div>
+              <div className={styles.works}>Work</div>
             </Link>
             {/* was: session-gated — worms is now public */}
             {/* {session ? (

--- a/components/Sidebar/index.js
+++ b/components/Sidebar/index.js
@@ -1,0 +1,81 @@
+import useSWR from "swr";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useState } from "react";
+import WormPicture from "@/components/Worms";
+import styles from "./sidebar.module.css";
+
+export default function Sidebar({ isOpen }) {
+  const router = useRouter();
+  const { data: wormData } = useSWR("/api/worms/");
+  const { data: workData } = useSWR("/api/works");
+
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedType, setSelectedType] = useState("all");
+
+  if (!wormData || !workData) return null;
+
+  // same worm as homepage
+  const desiredWormId = "6568862e2ff078c1d2b0adf1";
+  const selectedWorm = wormData.find((worm) => worm._id === desiredWormId);
+
+  const uniqueTypes = [...new Set(workData.flatMap((work) => work.type))];
+
+  const handleSearchChange = (query) => {
+    setSearchQuery(query);
+    // navigate to homepage with search query param
+    router.push({ pathname: "/", query: { search: query, type: selectedType } });
+  };
+
+  const handleTypeChange = (type) => {
+    setSelectedType(type);
+    // navigate to homepage with type query param
+    router.push({ pathname: "/", query: { search: searchQuery, type } });
+  };
+
+  return (
+    <aside className={`${styles.sidebar} ${!isOpen ? styles.sidebarClosed : ""}`}>
+      {selectedWorm && <WormPicture selectedWorm={selectedWorm} />}
+
+      <h3 className={styles.bio}>
+        <Link href="/contact">Ana Cecilia Breña</Link> is a Mexican designer
+        currently working with{" "}
+        <a href="https://www.santiagodasilva.com/" target="_blank">
+          Studio Santiago da Silva
+        </a>{" "}
+        in{" "}
+        <a href="https://maps.app.goo.gl/xLqE6SFSnQnYHpVr8" target="_blank">
+          Berlin.
+        </a>
+      </h3>
+
+      <div className={styles.searchBar}>
+        <h3>Search for a work</h3>
+        <input
+          type="text"
+          placeholder="Search By Title..."
+          value={searchQuery}
+          onChange={(e) => handleSearchChange(e.target.value)}
+          className={styles.searchInput}
+        />
+        <div className={styles.typeOptions}>
+          <div
+            className={`${styles.typeOption} ${selectedType === "all" ? styles.selected : ""}`}
+            onClick={() => handleTypeChange("all")}
+          >
+            All
+          </div>
+          {uniqueTypes.map((type) => (
+            <div
+              key={type}
+              className={`${styles.typeOption} ${selectedType === type ? styles.selected : ""}`}
+              onClick={() => handleTypeChange(type)}
+            >
+              {type}
+            </div>
+          ))}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/components/Sidebar/sidebar.module.css
+++ b/components/Sidebar/sidebar.module.css
@@ -1,0 +1,62 @@
+.sidebar {
+  position: fixed;
+  top: 80px; /* below fixed header */
+  left: 0;
+  width: 280px;
+  height: calc(100vh - 80px);
+  padding: 20px 20px 20px 50px; /* 50px left padding */
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  font-family: monospace;
+  background-color: transparent;
+  /* slide in/out transition */
+  transform: translateX(0);
+  transition: transform 0.3s ease;
+  z-index: 1000;
+}
+
+.sidebarClosed {
+  transform: translateX(-100%);
+}
+
+.bio {
+  font-size: 16px;
+  font-family: monospace;
+  max-width: 240px;
+}
+
+.searchBar {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.searchBar h3 {
+  font-family: monospace;
+  font-size: 16px;
+}
+
+.searchInput {
+  width: 100%;
+  padding: 6px;
+  font-family: monospace;
+}
+
+.typeOptions {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.typeOption {
+  cursor: pointer;
+  font-family: monospace;
+  font-size: 14px;
+}
+
+.selected {
+  background-color: #007bff;
+  color: #fff;
+}

--- a/components/WorkDetails/index.js
+++ b/components/WorkDetails/index.js
@@ -15,10 +15,12 @@ export default function WorkDetails() {
   console.log("where is my data????", data);
   console.log("slug?????", slug);
 
-  // useEffect(() => {
-  //   const setBackgroundColor = data?.color || "#FFFFFF";
-  //   document.querySelector("body").style.backgroundColor = setBackgroundColor;
-  // }, [data]);
+  useEffect(() => {
+    // set background on body so it covers full viewport including behind the sidebar
+    document.querySelector("body").style.backgroundColor = data?.color || "#FFFFFF";
+    // reset when leaving the page
+    return () => { document.querySelector("body").style.backgroundColor = ""; };
+  }, [data]);
 
   if (isLoading) {
     return <h1>Loading...</h1>;

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,8 +1,10 @@
 import GlobalStyle from "../styles";
 import { SWRConfig } from "swr";
 import Header from "@/components/Header";
+import Sidebar from "@/components/Sidebar";
 import { SessionProvider } from "next-auth/react";
 import { ThemeProvider } from "next-themes";
+import { useState, useEffect } from "react";
 
 const fetcher = (url) => fetch(url).then((response) => response.json());
 
@@ -10,6 +12,16 @@ export default function App({
   Component,
   pageProps: { session, ...pageProps },
 }) {
+  // open by default on desktop, closed on mobile
+  const [sidebarOpen, setSidebarOpen] = useState(true);
+
+  useEffect(() => {
+    // close sidebar by default on small screens
+    if (window.innerWidth < 768) {
+      setSidebarOpen(false);
+    }
+  }, []);
+
   return (
     <>
       <ThemeProvider
@@ -23,10 +35,42 @@ export default function App({
           <SWRConfig value={{ fetcher }}>
             <GlobalStyle />
             <Header />
-            {/* padding-top clears the fixed header so content doesn't hide under it */}
-            <main style={{ paddingTop: "80px" }}>
-              <Component {...pageProps} />
-            </main>
+            <div style={{ display: "flex", paddingTop: "80px" }}>
+              <Sidebar isOpen={sidebarOpen} />
+
+              {/* pink circle toggle button — always visible */}
+              <button
+                onClick={() => setSidebarOpen((prev) => !prev)}
+                style={{
+                  position: "fixed",
+                  // sits at the edge of the sidebar when open, stays put when closed
+                  left: sidebarOpen ? "268px" : "8px",
+                  top: "100px",
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  zIndex: 1100,
+                  transition: "left 0.3s ease",
+                  padding: 0,
+                }}
+                aria-label="Toggle sidebar"
+              >
+                <svg width="22" height="22" viewBox="0 0 22 22">
+                  <circle cx="11" cy="11" r="11" fill="pink" />
+                </svg>
+              </button>
+
+              {/* main content shifts right when sidebar is open, on desktop only */}
+              <main
+                style={{
+                  marginLeft: sidebarOpen ? "280px" : "0px",
+                  flex: 1,
+                  transition: "margin-left 0.3s ease",
+                }}
+              >
+                <Component {...pageProps} />
+              </main>
+            </div>
           </SWRConfig>
         </SessionProvider>
       </ThemeProvider>

--- a/pages/homepage.module.css
+++ b/pages/homepage.module.css
@@ -3,16 +3,7 @@
   padding: 20px;
 }
 
-.contentWrapper {
-  display: flex;
-  margin-top: 10px;
-  margin-left: 24px;
-  justify-content: space-between;
-  flex-direction: column;
-  position: fixed;
-  top: 0;
-  padding-top: 80px; /* push content below fixed header */
-}
+/* contentWrapper removed — sidebar now lives globally in _app.js */
 
 .title {
   flex: 1;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,123 +1,74 @@
-import WormPicture from "@/components/Worms";
 import useSWR from "swr";
 import styles from "./homepage.module.css";
 import Link from "next/link";
 import Image from "next/image";
-import SearchBar from "@/components/SearchBar";
 import { useState, useEffect } from "react";
+import { useRouter } from "next/router";
 
 export default function HomePage() {
-  const { data: wormData, isLoading: wormsAreLoading } = useSWR(`/api/worms/`);
+  const router = useRouter();
+  // read search and type from query params set by the sidebar
+  const { search = "", type = "all" } = router.query;
+
   const { data: workData, isLoading: worksAreLoading } = useSWR("/api/works");
-  const [selectedType, setSelectedType] = useState("all");
-  const [searchQuery, setSearchQuery] = useState("");
   const [showBackToTop, setShowBackToTop] = useState(false);
 
   useEffect(() => {
     const handleScroll = () => {
-      setShowBackToTop(window.scrollY > 200); // Adjust the scroll threshold as needed
+      setShowBackToTop(window.scrollY > 200);
     };
-
     window.addEventListener("scroll", handleScroll);
-
-    return () => {
-      window.removeEventListener("scroll", handleScroll);
-    };
+    return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
-  if (wormsAreLoading || worksAreLoading) {
+  if (worksAreLoading) {
     return <h5>   ... some worms are loading now :) </h5>;
   }
 
-  if (!wormData || !workData) {
+  if (!workData) {
     return <p>Data not found</p>;
   }
 
-  //find specific worm//
-  const desiredWormId = "6568862e2ff078c1d2b0adf1";
-  const selectedWorm = wormData.find((worm) => worm._id === desiredWormId);
-  if (!selectedWorm) {
-    return <p>Invalid Worm</p>;
-  }
-  //find works by type//
+  // build works-by-type map for type filtering
   const worksByType = workData.reduce((acc, work) => {
-    work.type.forEach((type) => {
-      if (!acc[type]) {
-        acc[type] = [];
-      }
-      acc[type].push(work);
+    work.type.forEach((t) => {
+      if (!acc[t]) acc[t] = [];
+      acc[t].push(work);
     });
     return acc;
   }, {});
 
-  const uniqueTypes = Object.keys(worksByType);
-
+  // filter by search query and type from sidebar
   const displayedWorks = workData
-    .filter((work) =>
-      work.title.toLowerCase().includes(searchQuery.toLowerCase())
-    )
-    .filter(
-      (work) =>
-        selectedType === "all" || worksByType[selectedType]?.includes(work)
-    );
+    .filter((work) => work.title.toLowerCase().includes(search.toLowerCase()))
+    .filter((work) => type === "all" || worksByType[type]?.includes(work));
 
   const handleBackToTop = () => {
     window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
   return (
-    <>
-      <div className={styles.homePage}>
-        <div className={styles.contentWrapper}>
-          <WormPicture className={styles.worm} selectedWorm={selectedWorm} />
-          <h3 className={styles.text}>
-            <Link href="/contact">Ana Cecilia Breña</Link> is a Mexican designer
-            currently working with{" "}
-            <a href="https://www.santiagodasilva.com/" target="_blank">
-              Studio Santiago de Silva
-            </a>{" "}
-            in{" "}
-            <a href="https://maps.app.goo.gl/xLqE6SFSnQnYHpVr8" target="_blank">
-              Berlin.
-            </a>
-            
-          </h3>
-          <SearchBar
-            uniqueTypes={uniqueTypes}
-            workData={workData}
-            onSearch={(query, type) => {
-              setSearchQuery(query);
-              setSelectedType(type);
-            }}
-          />
-        </div>
-
-     
-
-        <div className={styles.images}>
-          {displayedWorks.map((work) => (
-            <div key={work.id}>
-              <Link href={`/works/${work.slug}`}>
-                <Image
-                  style={{ objectFit: "contain" }}
-                  src={work.images[0]}
-                  alt={`Image of ${work.title}`}
-                  width={600}
-                  height={620}
-                />
-              </Link>
-            </div>
-          ))}
-          {showBackToTop && (
-            <button
-              className={styles.backToTopButton}
-              onClick={handleBackToTop}
-            >
-              Back to Top
-            </button>
-          )}
-        </div>
+    <div className={styles.homePage}>
+      <div className={styles.images}>
+        {displayedWorks.map((work) => (
+          <div key={work.id}>
+            <Link href={`/works/${work.slug}`}>
+              <Image
+                style={{ objectFit: "contain" }}
+                src={work.images[0]}
+                alt={`Image of ${work.title}`}
+                width={600}
+                height={620}
+              />
+            </Link>
+          </div>
+        ))}
+        {showBackToTop && (
+          <button className={styles.backToTopButton} onClick={handleBackToTop}>
+            Back to Top
+          </button>
+        )}
       </div>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
- New Sidebar component with worm, bio text, and search bar
- Search navigates to homepage via query params (?search=&type=)
- Homepage reads search/type from query params instead of local state
- Sidebar is toggleable with a pink circle SVG button
- Open by default on desktop, closed on mobile
- Transparent background, monospace font, 50px left padding
- WorkDetails sets body background color so it shows through sidebar